### PR TITLE
🐛 Python editor now displays internal qubit label instead of user declared ones for all qubits

### DIFF
--- a/python/mqt/syrec/syrec_editor.py
+++ b/python/mqt/syrec/syrec_editor.py
@@ -541,15 +541,10 @@ class SyReCEditor(QtWidgets.QWidget):  # type: ignore[misc]
         self.table.verticalHeader().setVisible(False)
 
         for i in range(no_of_bits):
-            to_be_displayed_qubit_label_type = (
-                syrec.qubit_label_type.internal
-                if self.annotatable_quantum_computation.is_circuit_qubit_ancillary(i)
-                else syrec.qubit_label_type.user_declared
-            )
+            # One could display the user declared qubit label for the qubits of the local variables of a module but since these variable identifiers could be identical to ones from a different module, we display the internal qubit label instead.
             io_qubit_label: str | None = self.annotatable_quantum_computation.get_qubit_label(
-                i, to_be_displayed_qubit_label_type
+                i, syrec.qubit_label_type.internal
             )
-
             # Fetching the matching label for a qubit of the annotatable quantum computation should not fail but in case it does, assume a default qubit label <UNKNOWN>.
             # We still display the column in any case because otherwise the user would be shown a different number of qubits than the number of qubits that actual exist in the annotatable quantum computation.
             if io_qubit_label is None:


### PR DESCRIPTION
## Description

Instead of fetching the use-declared qubit label for non-ancillary qubits we always fetch the internal label instead since user declared qubit labels are only available for the local variables of a SyReC module which additionally are not unique since as the name suggests local variables are only unique to the module in which the are declared. Thus we display the globally unique internal qubit label instead (improvements to also include the qubit inline information could be made with #28)

Fixes #480

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are focused and relevant to this change.
- [X] I have added appropriate tests that cover the new/changed functionality.
- [X] I have updated the documentation to reflect these changes.
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.
