### PR TITLE
🔥 Stop building 3.13t wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,14 +257,14 @@ ignore = ["GH200"]
 [tool.cibuildwheel]
 build = "cp3*"
 manylinux-aarch64-image = "quay.io/pypa/manylinux_2_39_aarch64:latest"
-skip = "*-musllinux_*"
+skip = ["*-musllinux_*", "cp313t-*"]
 archs = "auto64"
 test-groups = ["test"]
 test-command = "pytest {project}/test/python"
 build-frontend = "build[uv]"
 enable = ["cpython-freethreading"]
 test-skip = [
-  "cp3*t-*", # no freethreading qiskit wheels
+  "cp3??t-*", # no freethreading qiskit wheels
   "cp*-win_arm64", # no numpy, qiskit, ... wheels
 ]
 
@@ -292,7 +292,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "13.3" }
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --ignore-missing-dependencies"
 
 [tool.cibuildwheel.windows]
-before-build = "uv pip install delvewheel>=1.9.0"
+before-build = "uv pip install delvewheel>=1.11.2"
 repair-wheel-command = """delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt \
 --exclude mqt-core-ir.dll \
 --exclude mqt-core-qasm.dll \


### PR DESCRIPTION
## Description

This PR removes Python 3.13t builds from the CD matrix due to their experimental nature.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
